### PR TITLE
Изменён publicPath для gh-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "docs": "vue-cli-service build --dest docs",
+    "gh-pages": "vue-cli-service build --dest docs",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
+    "docs": "vue-cli-service build --dest docs",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  publicPath: './',
   css: {
     loaderOptions: {
       // передача настроек в sass-loader


### PR DESCRIPTION
Если постаивть `publicPath: './'`, то в собранном `index.html` пути до файлов будут без `/` в начале. Через `vue-cli-service build --dest docs` будет собираться в папку подходящей для Github Pages. Остаётся в настройках репозитория включить Pages и создать ветку `gh-pages` в которой вызывать `npm run gh-pages` и пушить.